### PR TITLE
Handle when task_expires is None or Zero (0)

### DIFF
--- a/django_celery_results/managers.py
+++ b/django_celery_results/managers.py
@@ -156,6 +156,10 @@ class TaskResultManager(models.Manager):
 
     def delete_expired(self, expires):
         """Delete all expired results."""
+        if expires is None:
+            return
+        if expires == 0:
+            return
         with transaction.atomic():
             self.get_all_expired(expires).update(hidden=True)
             self.filter(hidden=True).delete()


### PR DESCRIPTION
Currently, when CELERY_RESULT_EXPIRES is set to None, will result in TypeError Exception
When CELERY_RESULT_EXPIRES is Zero (0), the results are deleted as soon as the 'backend_cleanup' task is run.
